### PR TITLE
remove extra comma in the juliapkg.json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Julia v1.*.* and the Example package v0.5.*:
     "packages": {
         "Example": {
             "uuid": "7876af07-990d-54b4-ab0e-23690620f79a",
-            "version": "0.5",
+            "version": "0.5"
         }
     }
 }


### PR DESCRIPTION
That comma caused this:
```python
>>> import juliacall
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/yakir/.local/lib/python3.7/site-packages/juliacall/__init__.py", line 137, in <module>
    init()
  File "/home/yakir/.local/lib/python3.7/site-packages/juliacall/__init__.py", line 95, in init
    CONFIG['exepath'] = exepath = juliapkg.executable()
  File "/home/yakir/.local/lib/python3.7/site-packages/juliapkg/deps.py", line 274, in executable
    resolve()
  File "/home/yakir/.local/lib/python3.7/site-packages/juliapkg/deps.py", line 223, in resolve
    compat = required_julia()
  File "/home/yakir/.local/lib/python3.7/site-packages/juliapkg/deps.py", line 194, in required_julia
    deps = json.load(fp)
  File "/usr/lib/python3.7/json/__init__.py", line 296, in load
    parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 7 column 9 (char 157)
```