### PR TITLE
fix `JULIA_PROJECT=@.` logic

### DIFF
--- a/src/juliapkg/state.py
+++ b/src/juliapkg/state.py
@@ -28,10 +28,14 @@ def reset_state():
                     if os.path.exists(os.path.join(project, fn)):
                         STATE['project'] = project
                         break
-                project2 = os.path.dirname(project)
-                if project2 == project:
-                    raise Exception('JULIA_PROJECT=@. but could not find the project directory')
-                project = project2
+                else:
+                    project2 = os.path.dirname(project)
+                    if project2 == project:
+                        # TODO: actually here we should fall back to the defaut v#.# environment, not error
+                        raise Exception('JULIA_PROJECT=@. but could not find the project directory')
+                    project = project2
+                    continue
+                break
         else:
             STATE['project'] = project
     else:


### PR DESCRIPTION
Previously the `break` only broke out of the for loop but guessing you intended it to break out of both loops. This achieves I think the intended logic instead. Note also that if we don't find anything, the thing to do would be to default to the `v#.#` environment, at least thats what Julia itself does. I left that in as a comment but I'm not sure how to best do that. 

