### PR TITLE
Add option to merge Julia dependencies found in `juliapkg.json` files with existing `Project.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ following strategies in order:
   subdirectory is used.
 - Otherwise `~/.julia/environments/pyjuliapkg` is used (respects `JULIA_DEPOT`).
 
-If the project location found by the strategy above contains a `Project.toml` it will be overwritten unless the environment variable `PYTHON_JULIA_MERGE_PROJECT` is non-empty.
+If the project location found by the strategy above contains a `Project.toml` it will be overwritten unless the environment variable `PYTHON_JULIAPKG_MERGE_PROJECT` is non-empty.
 Otherwise JuliaPkg will attempt to merge the Julia dependencies it finds in the `juliapkg.json` file(s) into the existing `Project.toml`.
 An error will be raised if the combination of Julia packages are not compatible with each other.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ following strategies in order:
   subdirectory is used.
 - Otherwise `~/.julia/environments/pyjuliapkg` is used (respects `JULIA_DEPOT`).
 
+If the project location found by the strategy above contains a `Project.toml` it will be overwritten unless the environment variable `PYTHON_JULIA_MERGE_PROJECT` is non-empty.
+Otherwise JuliaPkg will attempt to merge the Julia dependencies it finds in the `juliapkg.json` file(s) into the existing `Project.toml`.
+An error will be raised if the combination of Julia packages are not compatible with each other.
+
 More strategies may be added in a future release.
 
 ### Adding Julia dependencies to Python packages

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = juliapkg
-version = 0.1.5
+version = 0.2.0
 description = Julia version manager and package manager
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ package_dir =
     =src
 install_requires =
     semantic_version ~=2.9
+    tomli >= 1.1.0 ; python_version < "3.11"
+    tomli-w
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This PR changes the behavior of JuliaPkg when the environment variable `PYTHON_JULIAPKG_MERGE_PROJECT` is non-empty. When that's true, JuliaPkg will attempt to merge the Julia dependencies found in the `juliapkg.json` files into the `Project.toml` file instead of overwriting it. It finds compatible ranges of versions fo each Julia package using JuliaPkg's `Compat` class. I added a description of this option to the `README.md`.

This change is motivated by the following use case for JuliaPkg: I have a Julia package (call it FooBase.jl) that I want to add as a dependency to a Python package (call it pyfoo). Then I'd like to use pyfoo and FooBase.jl in a Julia package Foo.jl. To do that, I need to make sure the version of FooBase.jl that pyfoo uses is compatible/the same as the one I'll use in Foo.jl. The easiest solution I could think of is to make JuliaPkg use the same Project.toml as whatever I'm using in Julia through the `PYTHON_JULIAPKG_PROJECT` variable, and then let the Julia package manager figure out the compatible versions.
