### PR TITLE
Fix for #81: Compatibility with new JuliaUp logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Compat fix for juliaup 1.19.8.
+
 ## v0.1.22 (2025-10-08)
 * Bug fixes.
 

--- a/src/juliapkg/find_julia.py
+++ b/src/juliapkg/find_julia.py
@@ -195,13 +195,9 @@ def ju_find_julia_noinstall(compat=None):
                 if "Path" in info:
                     ext = ".exe" if os.name == "nt" else ""
                     if "BinaryPath" in info and info["BinaryPath"].endswith("julia" + ext):
-                        exe = os.path.abspath(
-                            os.path.join(judir, info["BinaryPath"] + ext)
-                        )
+                        exe = os.path.abspath(os.path.join(judir, info["BinaryPath"] + ext))
                     else:
-                        exe = os.path.abspath(
-                            os.path.join(judir, info["Path"], "bin", "julia" + ext)
-                        )
+                        exe = os.path.abspath(os.path.join(judir, info["Path"], "bin", "julia" + ext))
                     versions.append((exe, ver))
         versions.sort(key=lambda x: x[1], reverse=True)
         for exe, _ in versions:

--- a/src/juliapkg/find_julia.py
+++ b/src/juliapkg/find_julia.py
@@ -192,18 +192,14 @@ def ju_find_julia_noinstall(compat=None):
                 continue
             ver = Version(ver.major, ver.minor, ver.patch)
             if compat is None or ver in compat:
-                if "Path" in info:
+                if "BinaryPath" in info:
+                    exe = os.path.abspath(os.path.join(judir, info["BinaryPath"]))
+                    versions.append((exe, ver))
+                elif "Path" in info:
                     ext = ".exe" if os.name == "nt" else ""
-                    if "BinaryPath" in info and info["BinaryPath"].endswith(
-                        "julia" + ext
-                    ):
-                        exe = os.path.abspath(
-                            os.path.join(judir, info["BinaryPath"] + ext)
-                        )
-                    else:
-                        exe = os.path.abspath(
-                            os.path.join(judir, info["Path"], "bin", "julia" + ext)
-                        )
+                    exe = os.path.abspath(
+                        os.path.join(judir, info["Path"], "bin", "julia" + ext)
+                    )
                     versions.append((exe, ver))
         versions.sort(key=lambda x: x[1], reverse=True)
         for exe, _ in versions:

--- a/src/juliapkg/find_julia.py
+++ b/src/juliapkg/find_julia.py
@@ -194,13 +194,16 @@ def ju_find_julia_noinstall(compat=None):
             if compat is None or ver in compat:
                 if "Path" in info:
                     ext = ".exe" if os.name == "nt" else ""
-                    if ("BinaryPath" in info and
-                        info["BinaryPath"].endswith("julia" + ext)):
+                    if "BinaryPath" in info and info["BinaryPath"].endswith(
+                        "julia" + ext
+                    ):
                         exe = os.path.abspath(
-                            os.path.join(judir, info["BinaryPath"] + ext))
+                            os.path.join(judir, info["BinaryPath"] + ext)
+                        )
                     else:
                         exe = os.path.abspath(
-                            os.path.join(judir, info["Path"], "bin", "julia" + ext))
+                            os.path.join(judir, info["Path"], "bin", "julia" + ext)
+                        )
                     versions.append((exe, ver))
         versions.sort(key=lambda x: x[1], reverse=True)
         for exe, _ in versions:

--- a/src/juliapkg/find_julia.py
+++ b/src/juliapkg/find_julia.py
@@ -194,10 +194,13 @@ def ju_find_julia_noinstall(compat=None):
             if compat is None or ver in compat:
                 if "Path" in info:
                     ext = ".exe" if os.name == "nt" else ""
-                    if "BinaryPath" in info and info["BinaryPath"].endswith("julia" + ext):
-                        exe = os.path.abspath(os.path.join(judir, info["BinaryPath"] + ext))
+                    if ("BinaryPath" in info and
+                        info["BinaryPath"].endswith("julia" + ext)):
+                        exe = os.path.abspath(
+                            os.path.join(judir, info["BinaryPath"] + ext))
                     else:
-                        exe = os.path.abspath(os.path.join(judir, info["Path"], "bin", "julia" + ext))
+                        exe = os.path.abspath(
+                            os.path.join(judir, info["Path"], "bin", "julia" + ext))
                     versions.append((exe, ver))
         versions.sort(key=lambda x: x[1], reverse=True)
         for exe, _ in versions:

--- a/src/juliapkg/find_julia.py
+++ b/src/juliapkg/find_julia.py
@@ -194,9 +194,14 @@ def ju_find_julia_noinstall(compat=None):
             if compat is None or ver in compat:
                 if "Path" in info:
                     ext = ".exe" if os.name == "nt" else ""
-                    exe = os.path.abspath(
-                        os.path.join(judir, info["Path"], "bin", "julia" + ext)
-                    )
+                    if "BinaryPath" in info and info["BinaryPath"].endswith("julia" + ext):
+                        exe = os.path.abspath(
+                            os.path.join(judir, info["BinaryPath"] + ext)
+                        )
+                    else:
+                        exe = os.path.abspath(
+                            os.path.join(judir, info["Path"], "bin", "julia" + ext)
+                        )
                     versions.append((exe, ver))
         versions.sort(key=lambda x: x[1], reverse=True)
         for exe, _ in versions:


### PR DESCRIPTION
As per #81, JuliaUp recently changed how binaries are addressed, breaking automatically finding the Julia installation with `juliapkg`. 
I have tested this change on Julia 1.12.5 with Juliaup 1.19.8 and it resolved the issue. 
This is a relatively simple change, I hope a hotfix release can be created for it. 
Thank you for your work on this very useful package!